### PR TITLE
Make buildable, stable version of initial MultiEditorProvider

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -53,6 +53,8 @@ module.name_mapper='^@lexical/react/DEPRECATED_useLexicalHistory' -> '<PROJECT_R
 
 module.name_mapper='^@lexical/react/LexicalComposer' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalComposer.js.flow'
 module.name_mapper='^@lexical/react/LexicalComposerContext' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalComposerContext.js.flow'
+module.name_mapper='^@lexical/react/LexicalMultiEditorContext' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalMultiEditorContext.js.flow'
+module.name_mapper='^@lexical/react/LexicalMultiEditorProvider' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalMultiEditorProvider.js.flow'
 module.name_mapper='^@lexical/react/LexicalNestedComposer' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalNestedComposer.js.flow'
 module.name_mapper='^@lexical/react/LexicalContentEditable' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalContentEditable.js.flow'
 module.name_mapper='^@lexical/react/LexicalTreeView' -> '<PROJECT_ROOT>/packages/lexical-react/flow/LexicalTreeView.js.flow'

--- a/packages/lexical-react/src/LexicalComposerContext.ts
+++ b/packages/lexical-react/src/LexicalComposerContext.ts
@@ -13,6 +13,7 @@ import invariant from 'shared/invariant';
 
 export type LexicalComposerContextType = {
   getTheme: () => EditorThemeClasses | null | undefined;
+  multiEditorKey?: string;
 };
 
 export type LexicalComposerContextWithEditor = [
@@ -29,6 +30,7 @@ export const LexicalComposerContext: React.Context<
 export function createLexicalComposerContext(
   parent: LexicalComposerContextWithEditor | null | undefined,
   theme: EditorThemeClasses | null | undefined,
+  multiEditorKey?: string,
 ): LexicalComposerContextType {
   let parentContext: LexicalComposerContextType | null = null;
 
@@ -46,6 +48,7 @@ export function createLexicalComposerContext(
 
   return {
     getTheme,
+    multiEditorKey,
   };
 }
 

--- a/packages/lexical-react/src/LexicalHistoryPlugin.ts
+++ b/packages/lexical-react/src/LexicalHistoryPlugin.ts
@@ -3,8 +3,8 @@
 import type {HistoryState} from '@lexical/history';
 
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {useInternalLexicalMultiEditorContextConfig} from '@lexical/react/LexicalMultiEditorContext';
 
-import {useLexicalMultiEditorProviderContextConfig} from './LexicalMultiEditorContext';
 import {useHistory} from './shared/useHistory';
 
 export {createEmptyHistoryState} from '@lexical/history';
@@ -13,29 +13,20 @@ export type {HistoryState};
 
 export function HistoryPlugin({
   externalHistoryState,
-  initialMultiEditorProviderConfig,
 }: {
   externalHistoryState?: HistoryState;
-  initialMultiEditorProviderConfig?: Readonly<{
-    editorId: string;
-  }>;
 }): null {
-  const [editor] = useLexicalComposerContext();
-  const multiEditorProviderContextConfig =
-    useLexicalMultiEditorProviderContextConfig(
-      initialMultiEditorProviderConfig?.editorId,
-      'LexicalHistoryPlugin',
-    );
+  const [editor, context] = useLexicalComposerContext();
+  const multiEditorContext = useInternalLexicalMultiEditorContextConfig(
+    context.multiEditorKey,
+  );
 
-  const externalHistoryStateFromMultiEditorProviderContext =
-    multiEditorProviderContextConfig.state !== 'inactive'
-      ? multiEditorProviderContextConfig.history
+  const multiEditorContextHistoryState =
+    multiEditorContext.state === 'remountable'
+      ? multiEditorContext.history
       : undefined;
 
-  useHistory(
-    editor,
-    externalHistoryStateFromMultiEditorProviderContext || externalHistoryState,
-  );
+  useHistory(editor, multiEditorContextHistoryState || externalHistoryState);
 
   return null;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -162,6 +162,12 @@
       "@lexical/react/LexicalAutoScrollPlugin": [
         "./packages/lexical-react/src/LexicalAutoScrollPlugin.ts"
       ],
+      "@lexical/react/LexicalMultiEditorProvider": [
+        "./packages/lexical-react/src/LexicalMultiEditorProvider.tsx"
+      ],
+      "@lexical/react/LexicalMultiEditorContext": [
+        "./packages/lexical-react/src/LexicalMultiEditorContext.ts"
+      ],
 
       "@lexical/dragon/LexicalDragon": ["./packages/lexical-dragon/src/"],
       "@lexical/history/LexicalHistory": ["./packages/lexical-history/src/"],


### PR DESCRIPTION
Commit notes: 

rather than referencing a common existing version), fix closure-compiler errors (problem with ChainExpression implementation in acorn/walk version used by @ampproject/rollup-plugin-closure-compiler), better naming, tightened code...

Also added some relevant ancillaries, .flowconfig and tsconfig.json.